### PR TITLE
Bump PG version to fixed 10

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 ROOTPASS=omero
 # Other configuration properties
 POSTGRES_IMAGE=postgres
-POSTGRES_VERSION=9.6.13
+POSTGRES_VERSION=10
 POSTGRES_PASSWORD=postgres
 OMERO_SERVER_IMAGE=openmicroscopy/omero-server
 OMERO_SERVER_VERSION=5.5


### PR DESCRIPTION
10.10 has now been released with the correction. See https://github.com/ome/omero-install/issues/212 for more information.