### PR TITLE
cap dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pep8-naming
 pycodestyle<2.4.0
 restructuredtext_lint
 pytest==3.3.2
+attrs==19.1.0
 restview
 mox
 # TODO: Apps only


### PR DESCRIPTION
Failure started to show in figure when running pytest
```
File "/usr/lib/python2.7/site-packages/_pytest/fixtures.py", line 844, in FixtureFunctionMarker
    params = attr.ib(convert=attr.converters.optional(tuple))
TypeError: attrib() got an unexpected keyword argument 'convert'
```
Using the changes in this PR fixes the issue
see https://travis-ci.org/jburel/omero-figure/builds/593038191