### PR TITLE
Check .omeroci/env for env-vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ overridden by placing an executable file of the same name in an
  * `py-common` runs standard Python package build steps
  * `py-setup` builds and install the Python package
 
+You can also define a custom environment:
+* `env` will be sourced before any commands are run
+
 ### Environment variables ###
 
 The .env defines a number of variables that can optionally be passed

--- a/docker
+++ b/docker
@@ -7,6 +7,10 @@ set -u
 ##
 
 . .omero/utils
+if [ -f .omeroci/env ]; then
+    . .omeroci/env
+fi
+
 export ACTION=${ACTION:-""}
 export TRAVIS=${TRAVIS:-"false"}
 export VERBOSE=${VERBOSE:-"set +x"}


### PR DESCRIPTION
This is useful where environment variables always need to be set, regardless of the test environment. For instance https://github.com/ome/omero-metadata/blob/v0.4.1/.travis.yml#L5 always requires `PLUGIN=metadata` to be set including when run locally, so it should be automatic and not require additional setup by the developer.