### PR TITLE
Set web environment variables

### DIFF
--- a/app-build
+++ b/app-build
@@ -14,4 +14,7 @@ DIR=$(setup_dir)
 # python setup.py test -t test* -i ${OMERO_DIST}/etc/ice.config -v
 
 set +u
-ICE_CONFIG=${OMERO_DIST}/etc/ice.config python $DIR/setup.py test
+export DJANGO_SETTINGS_MODULE=omeroweb.settings
+export OMERODIR=/opt/omero/web/OMERO.web
+export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
+python $DIR/setup.py test


### PR DESCRIPTION
In testing https://github.com/ome/omero-parade/pull/64, both DJANGO_SETTINGS_MODULE and OMERODIR needed to be set. I'm not sure if this should really be necessary but appears to work.

cc: @sbesson @will-moore 