### PR TITLE
Install wheel package alongside the upgraded 42.0.0

### DIFF
--- a/py-common
+++ b/py-common
@@ -9,5 +9,5 @@ TARGET=${TARGET:-..}
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd $TARGET
 
-pip install --upgrade setuptools
+pip install --upgrade setuptools wheel
 pip install -r $dir/requirements.txt


### PR DESCRIPTION
Since setuptools 42.0.0, the pip/wheel package is used for fetching and building wheels whenever available - see https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4200

Without this change, downstream plugins are starting fail with
```
ERROR: 'pip wheel' requires the 'wheel' package. To fix this, run: pip install wheel
```