### PR TITLE
Fix app-config omero.web.apps formatting

### DIFF
--- a/app-config
+++ b/app-config
@@ -9,4 +9,4 @@ cd $TARGET
 # add the app to omero.web.apps
 value=$(get_app_name)
 
-su - omero-web -c "env OMERODIR=$OMERODIR /opt/omero/web/venv3/bin/omero config set omero.web.apps '[\""$value"\"]'"
+su - omero-web -c "env OMERODIR=$OMERODIR /opt/omero/web/venv3/bin/omero config set omero.web.apps '[\"$value\"]'"

--- a/app-config
+++ b/app-config
@@ -6,7 +6,7 @@ set +u
 
 cd $TARGET
 
-# format the name of the app
-value="[\""$(get_app_name)"\"]"
+# add the app to omero.web.apps
+value=$(get_app_name)
 
-su - omero-web -c "env OMERODIR=$OMERODIR /opt/omero/web/venv3/bin/omero config set omero.web.apps $value"
+su - omero-web -c "env OMERODIR=$OMERODIR /opt/omero/web/venv3/bin/omero config set omero.web.apps '[\""$value"\"]'"


### PR DESCRIPTION
This fixes the ```json.decoder.JSONDecodeError: Expecting value: line 1 column 2 (char 1)```
seen at https://github.com/ome/omero-figure/pull/354 and
https://github.com/ome/omero-mapr/pull/57