### PR TITLE
build and install the wheel

### DIFF
--- a/py-setup
+++ b/py-setup
@@ -11,6 +11,7 @@ PLUGIN=${PLUGIN:-}
 cd $TARGET
 cd $(setup_dir)
 python setup.py sdist
-pip install -U dist/*.tar.gz
+python setup.py bdist_wheel
+pip install -U dist/*.whl
 python setup.py clean
 rm -rf dist *egg-info src/*egg-info


### PR DESCRIPTION
* Build and install the wheel
This is built for all apps/plugins in travis when we tag.
also an issue was noticed while trying to install figure not from the wheel see https://github.com/ome/omero-figure/pull/366