### PR TITLE
Remove deprecated usage of pytest-runner

### DIFF
--- a/app-build
+++ b/app-build
@@ -17,4 +17,4 @@ set +u
 export DJANGO_SETTINGS_MODULE=omeroweb.settings
 export OMERODIR=/opt/omero/web/OMERO.web
 export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
-python $DIR/setup.py test
+pytest -v

--- a/cli-build
+++ b/cli-build
@@ -14,4 +14,5 @@ PLUGIN=${PLUGIN:-$GUESS}
 export OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
 omero $PLUGIN -h
 
-python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -vs
+export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
+pytest -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,9 @@ pep8-naming
 pre-commit
 pycodestyle
 restructuredtext_lint
-pytest<5
+pytest
 attrs
 restview
-mox
+pytest-mock
 # TODO: Apps only
 pytest-django
-pytest-runner

--- a/scripts-build
+++ b/scripts-build
@@ -8,4 +8,5 @@ set -x
 
 cd $TARGET
 
-python setup.py test -t test -i ${OMERO_DIST}/etc/ice.config -v
+export ICE_CONFIG=${OMERO_DIST}/etc/ice.config
+pytest -v


### PR DESCRIPTION
Fixes  #60 

- Call pytest directly in app, cli and scripts builds
- Remove pytest-runner
- Uncap pytest and install pytest-mock by default

Included below is a list of downstream plugins using this infrastructure and updated. The last commit for each PR will be reverted once this is included:

- https://github.com/ome/omero-upload/pull/12
- https://github.com/ome/omero-metadata/pull/85
- https://github.com/ome/omero-figure/pull/542
- https://github.com/ome/omero-cli-duplicate/pull/24
- https://github.com/ome/omero-cli-render/pull/61
