### PR TITLE
Add 'ms' target for ./docker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+
+      - name: Test microservice infrastructure
+        run: |
+          cp -r ms/example /tmp/ms-example
+          cp -r . /tmp/ms-example/.omero
+          cd /tmp/ms-example
+          .omero/docker ms
+
       - name: Add variable
         run: |
           run: |

--- a/docker
+++ b/docker
@@ -235,6 +235,28 @@ for STAGE in $STAGES; do
             run --user test data || echo ignore
             run --local lib test
             ;;
+        ms)
+            # Similar command to `srv` which builds the containing
+            # directory (..) assuming that it is a microservice and
+            # therefore *also* starts the main server container.
+            export COMPONENT=server
+            export USER=omero-server
+            export COMPOSE_FILE=${COMPOSE_FILE:-"docker-compose.yml:ms/compose.yml"}
+            export OMERO_DIST="/opt/omero/server/OMERO.server"
+            export TARGET=/src
+            start_up
+            export CID=$(get_cid omero)
+            install --nosrc
+            wait_on_login --localhost
+
+            # Now that the server is running, test it
+            export USER=1000
+            export CID=$(get_cid test)
+            export TARGET="/src"
+            export OMERO_DIST="/src/dist"
+            install --nosrc
+            run --user ms test
+            ;;
         scripts)
             export COMPONENT=server
             export USER=omero-server

--- a/ms/compose.yml
+++ b/ms/compose.yml
@@ -1,0 +1,11 @@
+version: '3.4'
+
+services:
+  ms:
+    build:
+      context: ..
+      target: run
+      args:
+        - BUILD_IMAGE
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock

--- a/ms/example/Dockerfile
+++ b/ms/example/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:latest
+
+EXPOSE 8080
+WORKDIR /serve
+
+RUN mkdir /serve
+RUN echo "hello world" >> /serve/file.txt
+
+RUN apk --no-cache -U add python3 && \
+    apk upgrade --no-cache -U -a  
+# Patch OpenSSL vulnerability^
+
+ENTRYPOINT [ "python3", "-m", "http.server", "8080" ]

--- a/ms/test
+++ b/ms/test
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl http://ms:8080/file.txt


### PR DESCRIPTION
The `ms` target like the `srv` target builds the enclosing directory and starts it as a docker image but additionally starts up the standard `omero-server` container.